### PR TITLE
Updating composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,14 @@
     "sort-packages": true
   },
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.3",
     "composer/installers": "^1.4",
     "johnpbloch/wordpress": "5.*",
     "oscarotero/env": "^1.1.0",
     "vlucas/phpdotenv": "^3.0",
     "wpackagist-plugin/limit-login-attempts-reloaded": "*",
     "wpackagist-plugin/spinupwp": "*",
-    "wpackagist-theme/twentynineteen": "*"
+    "wpackagist-theme/twentytwentyone": "*"
   },
   "extra": {
     "wordpress-install-dir": "public/wp",


### PR DESCRIPTION
1. Updated minimum PHP version to minimum version SpinupWP supports -> 7.3
2. Updated WP default theme to twentytwentyone