### PR TITLE
Improve environment-specific config and add documentation

### DIFF
--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -10,10 +10,10 @@
 
 use \DeliciousBrains\SpinupWPComposerSite\App;
 
-App::define('WP_DEBUG', true);
-App::define('WP_DEBUG_LOG', true);
-App::define('WP_DEBUG_DISPLAY', false);
-App::define('SCRIPT_DEBUG', true);
+App::define( 'WP_DEBUG',         true );
+App::define( 'WP_DEBUG_LOG',     true );
+App::define( 'WP_DEBUG_DISPLAY', false );
+App::define( 'SCRIPT_DEBUG',     true );
 
 @ini_set( 'display_errors', E_ALL );
 

--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -1,10 +1,20 @@
 <?php
+/**
+ * This file contains a base config for a development environment.
+ *
+ * It can be overridden using a .env or .env.local file in the root directory
+ * of the project.
+ *
+ * Always use App::define() to define new constants in this file.
+ */
 
-define('WP_DEBUG', true);
-define('WP_DEBUG_LOG', true);
-define('WP_DEBUG_DISPLAY', false);
-define('SCRIPT_DEBUG', true);
+use \DeliciousBrains\SpinupWPComposerSite\App;
+
+App::define('WP_DEBUG', true);
+App::define('WP_DEBUG_LOG', true);
+App::define('WP_DEBUG_DISPLAY', false);
+App::define('SCRIPT_DEBUG', true);
 
 @ini_set( 'display_errors', E_ALL );
 
-define( 'DISALLOW_FILE_MODS', false );
+App::define( 'DISALLOW_FILE_MODS', false );

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -1,2 +1,11 @@
 <?php
-// Add any production specific config
+/**
+ * This file contains a base config for a production environment.
+ *
+ * It can be overridden using a .env or .env.local file in the root directory
+ * of the project
+ *
+ * Always use App::define() to define new constants in this file.
+ */
+
+// App::define( CONSTANT, 'production_value' );

--- a/config/environments/staging.php
+++ b/config/environments/staging.php
@@ -1,2 +1,11 @@
 <?php
-// Add any staging specific config
+/**
+ * This file contains a base config for a staging environment.
+ *
+ * It can be overridden using a .env or .env.local file in the root directory
+ * of the project
+ *
+ * Always use App::define() to define new constants in this file.
+ */
+
+// App::define( CONSTANT, 'staging_value' );


### PR DESCRIPTION
This PR uses the `App::define()` method to set the stored environment-specific constants. This allows them to be overridden with a `.env` or `.env.local` file.

I've also added explanatory comments to each of the stored environment-specific files.